### PR TITLE
Enable VAR parameters

### DIFF
--- a/src/ace/adm_set.py
+++ b/src/ace/adm_set.py
@@ -25,6 +25,7 @@ a cache database.
 '''
 import logging
 import os
+import traceback
 from typing import BinaryIO, List, Optional, Set
 from pyang.repository import Repository
 from sqlalchemy import create_engine
@@ -259,6 +260,10 @@ class AdmSet:
         :return: The number of ADMs read from that directory.
         '''
         LOGGER.debug('Loading from directories %s', dir_paths)
+        # workaround misuse
+        if isinstance(dir_paths, str):
+            LOGGER.warning('load_from_dirs() given a single directory instead of a list')
+            dir_paths = [dir]
 
         file_entries = []
         for dir_path in reversed(dir_paths):
@@ -362,6 +367,7 @@ class AdmSet:
                 'Failed to open or read the file %s: %s',
                 file_path, err
             )
+            LOGGER.debug('%s', traceback.format_exc())
             raise
 
         self._post_load(adm_new, del_dupe)

--- a/src/ace/adm_set.py
+++ b/src/ace/adm_set.py
@@ -26,7 +26,7 @@ a cache database.
 import logging
 import os
 import traceback
-from typing import BinaryIO, List, Optional, Set
+from typing import BinaryIO, List, Set, Union
 from pyang.repository import Repository
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
@@ -252,17 +252,15 @@ class AdmSet:
             item.is_file() and item.name.endswith('.yang')
         )
 
-    def load_from_dirs(self, dir_paths:List[str]) -> int:
-        ''' Scan a directory for JSON files and attempt to read them as
+    def load_from_dirs(self, dir_paths:Union[str, List[str]]) -> int:
+        ''' Scan directories for YANG files and attempt to read them as
         ADM definitions.
 
-        :param dir_paths: The directory paths to scan.
+        :param dir_paths: One or more directory paths to scan.
         :return: The number of ADMs read from that directory.
         '''
         LOGGER.debug('Loading from directories %s', dir_paths)
-        # workaround misuse
         if isinstance(dir_paths, str):
-            LOGGER.warning('load_from_dirs() given a single directory instead of a list')
             dir_paths = [dir]
 
         file_entries = []

--- a/src/ace/models.py
+++ b/src/ace/models.py
@@ -33,7 +33,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.orderinglist import ordering_list
 
-CURRENT_SCHEMA_VERSION = 16
+CURRENT_SCHEMA_VERSION = 17
 ''' Value of :attr:`SchemaVersion.version_num` '''
 
 Base = declarative_base()
@@ -426,7 +426,7 @@ class Oper(Base, AdmObjMixin, ParamMixin):
     result = relationship("TypeNameItem", foreign_keys=[result_id], cascade="all, delete")
 
 
-class Var(Base, AdmObjMixin, TypeUseMixin):
+class Var(Base, AdmObjMixin, ParamMixin, TypeUseMixin):
     ''' Variable value (VAR)'''
     __tablename__ = "var"
     # Unique ID of the row


### PR DESCRIPTION
Also add an API check with workaround for `AdmSet.load_from_dirs()`.

This is related to #5 for allowed ADM contents.