### PR TITLE
Properly decode parameter default values when present

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../src/'))
 
 # Configuration file for the Sphinx documentation builder.

--- a/src/ace/adm_yang.py
+++ b/src/ace/adm_yang.py
@@ -444,9 +444,13 @@ class Decoder:
                     name=param_stmt.arg,
                     typeobj=self._get_typeobj(param_stmt)
                 )
+
                 def_stmt = search_one_exp(param_stmt, (AMM_MOD, 'default'))
                 if def_stmt:
                     item.default_value = def_stmt.arg
+                    # actually check the content
+                    item.default_ari = self._handle_ari(def_stmt.arg)
+
                 orm_val.items.append(item)
 
             obj.parameters = orm_val

--- a/src/ace/models.py
+++ b/src/ace/models.py
@@ -22,8 +22,6 @@
 #
 ''' ORM models for the ADM and its contents.
 '''
-import logging
-from typing import List
 from sqlalchemy import (
     Column, ForeignKey, Integer, String, DateTime, Text, PickleType
 )

--- a/src/ace/typing.py
+++ b/src/ace/typing.py
@@ -77,7 +77,7 @@ class BaseType:
         '''
         return set()
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         raise NotImplementedError()
 
     def convert(self, obj:ARI) -> ARI:
@@ -125,7 +125,7 @@ class NullType(BuiltInType):
     def __init__(self):
         super().__init__(StructType.NULL)
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if not isinstance(obj, LiteralARI):
             return None
         if obj.type_id is not None and obj.type_id != self.type_id:
@@ -145,7 +145,7 @@ class BoolType(BuiltInType):
     def __init__(self):
         super().__init__(StructType.BOOL)
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if not isinstance(obj, LiteralARI):
             return None
         if obj.type_id is not None and obj.type_id != self.type_id:
@@ -184,7 +184,7 @@ class NumericType(BuiltInType):
         self.dom_min = dom_min
         self.dom_max = dom_max
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if not isinstance(obj, LiteralARI):
             return None
         if obj.type_id is not None and obj.type_id != self.type_id:
@@ -237,7 +237,7 @@ class StringType(BuiltInType):
     }
     ''' Required value type for target string type. '''
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if is_undefined(obj):
             return None
         if not isinstance(obj, LiteralARI):
@@ -275,7 +275,7 @@ class TimeType(BuiltInType):
     }
     ''' Required value type for target time type. '''
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if is_undefined(obj):
             return None
         if not isinstance(obj, LiteralARI):
@@ -321,7 +321,7 @@ class ContainerType(BuiltInType):
     }
     ''' Required value type for target time type. '''
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if is_undefined(obj):
             return None
         if not isinstance(obj, LiteralARI):
@@ -354,7 +354,7 @@ class ObjRefType(BuiltInType):
     def __init__(self, type_id=None):
         super().__init__(type_id)
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if not isinstance(obj, ReferenceARI):
             return None
         if self.type_id is not None and obj.ident.type_id != self.type_id:
@@ -381,7 +381,7 @@ class AnyType(BuiltInType):
     }
     ''' Required value type for target time type. '''
 
-    def get(self, obj:ARI) -> ARI:
+    def get(self, obj:ARI) -> Optional[ARI]:
         if is_undefined(obj):
             return None
         typ = self.VALUE_CLS[self.type_id]

--- a/tests/test_adm_yang.py
+++ b/tests/test_adm_yang.py
@@ -226,6 +226,7 @@ module empty {}
     }
     amm:parameter def {
       amm:type "//ietf-amm/TYPEDEF/expr";
+      amm:default "ari:/AC/()";
     }
   }
   amm:ctrl test1 {
@@ -248,11 +249,26 @@ module empty {}
         obj = adm.ctrl[0]
         self.assertIsInstance(obj, models.Ctrl)
         self.assertEqual("test1", obj.name)
+
         self.assertEqual(2, len(obj.parameters.items))
-        self.assertEqual("id", obj.parameters.items[0].name)
+        param = obj.parameters.items[0]
+        self.assertEqual("id", param.name)
         self.assertEqual(
             self._from_text('//ietf-amm/typedef/any'),
-            obj.parameters.items[0].typeobj.type_ari
+            param.typeobj.type_ari
+        )
+        self.assertIsNone(param.default_value)
+        self.assertIsNone(param.default_ari)
+        param = obj.parameters.items[1]
+        self.assertEqual("def", param.name)
+        self.assertEqual(
+            self._from_text('//ietf-amm/typedef/expr'),
+            param.typeobj.type_ari
+        )
+        self.assertEqual("ari:/AC/()", param.default_value)
+        self.assertEqual(
+            self._from_text('ari:/AC/()'),
+            param.default_ari
         )
 
         self.assertEqual(1, len(adm.edd))


### PR DESCRIPTION
This was not caught by earlier ACE tests.