### PR TITLE
Issue #18 - Execset handling typed nonce literals 

### DIFF
--- a/src/ace/ari_text/parsemod.py
+++ b/src/ace/ari_text/parsemod.py
@@ -339,6 +339,7 @@ def p_structlist_end(p):
 
 
 def p_structpair(p):
+    # Keys are case-insensitive so get folded to lower case
     '''structpair : VALSEG EQ VALSEG SC 
                   | VALSEG EQ typedlit SC'''
 
@@ -357,5 +358,4 @@ def p_error(p):
 
 def new_parser(**kwargs):
     obj = yacc.yacc(**kwargs)
-#    obj = yacc.yacc(debug=True, debuglog=LOGGER)
     return obj

--- a/tests/test_ari_text.py
+++ b/tests/test_ari_text.py
@@ -1020,7 +1020,8 @@ class TestAriText(unittest.TestCase):
             ("ari:/EXECSET/n=null;()", 0),
             ("ari:/EXECSET/N=null;()", 0),
             ("ari:/EXECSET/N=0xabcd;()", 0),
-            # FIXME: ("ari:/EXECSET/N=/UINT/0B0101;()", 0),
+            ("ari:/EXECSET/N=/UINT/0x0B0101;()", 0),
+            ("ari:/EXECSET/N=/UINT/1234;()", 0),
             ("ari:/EXECSET/n=1234;(//example/test/CTRL/hi)", 1),
             ("ari:/EXECSET/n=h'6869';(//example/test/CTRL/hi,//example/test/CTRL/eh)", 2),
         ]


### PR DESCRIPTION
EXECSET didn't previously support typed nonce literals so the `test_ari_text_decode_lit_typed_execset()` unit test was failing due to the `("ari:/EXECSET/N=/UINT/0x0B0101;()", 0)` test case. The parser had to be updated, because the structpair was only supporting VALSEG EQ VALSEG.

Note: the resulting structpair can now be a string or a typed value. We need to check every place structlists are parsed to make sure there aren't other typing mismatches. It might be best to have structpair return a typed or untyped value instead of a dictionary (it might be okay to say a VALSEG is always a typedlit but it might be that there are VALSEGs that are not typedlits).