### PR TITLE
Add ident abstract marking

### DIFF
--- a/src/ace/pyang/dtnma_amm.py
+++ b/src/ace/pyang/dtnma_amm.py
@@ -451,11 +451,13 @@ MODULE_EXTENSIONS = (
             OBJ_SUBS_PRE
             +[
                 ((MODULE_NAME, 'parameter'), '*'),
+                ((MODULE_NAME, 'abstract'), '*'),
                 ((MODULE_NAME, 'base'), '*'),
                 ('uses', '*'),
             ]
         ),
     ),
+    Ext('abstract', 'boolean'),
     Ext('base', 'ARI'),
 
     Ext('const', 'identifier',


### PR DESCRIPTION
Handle recently added abstract marking for IDENT objects.

This also fixes a problem where "amm:display-hint" was not properly registered as a usable extension under "amm:type".

Closes #63 