### PR TITLE
Store IDENT abstract marking in model

### DIFF
--- a/src/ace/adm_yang.py
+++ b/src/ace/adm_yang.py
@@ -483,6 +483,10 @@ class Decoder:
             obj.typeobj = self._get_typeobj(stmt)
 
         if issubclass(cls, Ident):
+            abs_stmt = stmt.search_one((AMM_MOD, 'abstract'))
+            if abs_stmt:
+                obj.abstract = (abs_stmt.arg == 'true')
+
             for base_stmt in stmt.search((AMM_MOD, 'base')):
                 base = IdentBase()
                 base.base_text = base_stmt.arg
@@ -508,72 +512,72 @@ class Decoder:
         elif issubclass(cls, Sbr):
             action_stmt = stmt.search_one((AMM_MOD, 'action'))
             if action_stmt:
-              obj.action_value = action_stmt.arg
-              obj.action_ari = self._get_ari(action_stmt.arg)
+                obj.action_value = action_stmt.arg
+                obj.action_ari = self._get_ari(action_stmt.arg)
             else:
-              LOGGER.warning('sbr "%s" is missing action substatement', stmt.arg)
+                LOGGER.warning('sbr "%s" is missing action substatement', stmt.arg)
 
             condition_stmt = stmt.search_one((AMM_MOD, 'condition'))
             if condition_stmt:
-              obj.condition_value = condition_stmt.arg
-              obj.condition_ari = self._get_ari(condition_stmt.arg)
+                obj.condition_value = condition_stmt.arg
+                obj.condition_ari = self._get_ari(condition_stmt.arg)
             else:
-              LOGGER.warning('sbr "%s" is missing condition substatement', stmt.arg)
+                LOGGER.warning('sbr "%s" is missing condition substatement', stmt.arg)
 
             min_interval_stmt = stmt.search_one((AMM_MOD, 'min-interval'))
             if min_interval_stmt:
-              obj.min_interval_value = min_interval_stmt.arg
-              obj.min_interval_ari = self._get_ari(min_interval_stmt.arg)
+                obj.min_interval_value = min_interval_stmt.arg
+                obj.min_interval_ari = self._get_ari(min_interval_stmt.arg)
             else:
-              obj.min_interval_value = "/TD/PT0S" # 0 sec default
-              obj.min_interval_ari = self._get_ari(obj.min_interval_value)
+                obj.min_interval_value = "/TD/PT0S"  # 0 sec default
+                obj.min_interval_ari = self._get_ari(obj.min_interval_value)
 
             max_count_stmt = stmt.search_one((AMM_MOD, 'max-count'))
             if max_count_stmt:
-              obj.max_count = int(max_count_stmt.arg)
+                obj.max_count = int(max_count_stmt.arg)
             else:
-              obj.max_count = 0
+                obj.max_count = 0
 
             enabled_stmt = stmt.search_one((AMM_MOD, 'init-enabled'))
             if enabled_stmt:
-              obj.init_enabled = (enabled_stmt.arg == 'true')
+                obj.init_enabled = (enabled_stmt.arg == 'true')
             else:
-              obj.init_enabled = True
+                obj.init_enabled = True
 
         elif issubclass(cls, Tbr):
             action_stmt = stmt.search_one((AMM_MOD, 'action'))
             if action_stmt:
-              obj.action_value = action_stmt.arg
-              obj.action_ari = self._get_ari(action_stmt.arg)
+                obj.action_value = action_stmt.arg
+                obj.action_ari = self._get_ari(action_stmt.arg)
             else:
-              LOGGER.warning('tbr "%s" is missing action substatement', stmt.arg)
+                LOGGER.warning('tbr "%s" is missing action substatement', stmt.arg)
 
             period_stmt = stmt.search_one((AMM_MOD, 'period'))
             if period_stmt:
-              obj.period_value = period_stmt.arg
-              obj.period_ari = self._get_ari(period_stmt.arg)
+                obj.period_value = period_stmt.arg
+                obj.period_ari = self._get_ari(period_stmt.arg)
             else:
-              LOGGER.warning('tbr "%s" is missing period substatement', stmt.arg)
+                LOGGER.warning('tbr "%s" is missing period substatement', stmt.arg)
 
             start_stmt = stmt.search_one((AMM_MOD, 'start'))
             if start_stmt:
-              obj.start_value = start_stmt.arg
-              obj.start_ari = self._get_ari(start_stmt.arg)
+                obj.start_value = start_stmt.arg
+                obj.start_ari = self._get_ari(start_stmt.arg)
             else:
-              obj.start_value = "/TD/PT0S" # 0 sec default
-              obj.start_ari = self._get_ari(obj.start_value)
+                obj.start_value = "/TD/PT0S"  # 0 sec default
+                obj.start_ari = self._get_ari(obj.start_value)
 
             max_count_stmt = stmt.search_one((AMM_MOD, 'max-count'))
             if max_count_stmt:
-              obj.max_count = int(max_count_stmt.arg)
+                obj.max_count = int(max_count_stmt.arg)
             else:
-              obj.max_count = 0
+                obj.max_count = 0
 
             enabled_stmt = stmt.search_one((AMM_MOD, 'init-enabled'))
             if enabled_stmt:
-              obj.init_enabled = (enabled_stmt.arg == 'true')
+                obj.init_enabled = (enabled_stmt.arg == 'true')
             else:
-              obj.init_enabled = True
+                obj.init_enabled = True
 
         elif issubclass(cls, Ctrl):
             result_stmt = stmt.search_one((AMM_MOD, 'result'), children=stmt.i_children)
@@ -916,6 +920,9 @@ class Encoder:
             self._put_typeobj(obj.typeobj, obj_stmt)
 
         if issubclass(cls, Ident):
+            if obj.abstract is not None:
+                self._add_substmt(obj_stmt, (AMM_MOD, 'abstract'), 'true' if obj.abstract else 'false')
+
             for base in obj.bases:
                 self._add_substmt(obj_stmt, (AMM_MOD, 'base'), base.base_text)
 

--- a/src/ace/models.py
+++ b/src/ace/models.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.orderinglist import ordering_list
 
-CURRENT_SCHEMA_VERSION = 19
+CURRENT_SCHEMA_VERSION = 20
 ''' Value of :attr:`SchemaVersion.version_num` '''
 
 Base = declarative_base()
@@ -367,6 +367,9 @@ class Ident(Base, AdmObjMixin, ParamMixin):
     module = relationship("AdmModule", back_populates="ident")
     ''' Relationship to the :class:`AdmModule` '''
 
+    abstract = Column(Boolean)
+    ''' Explicit abstract marking '''
+
     bases = relationship(
         "IdentBase",
         order_by="IdentBase.position",
@@ -469,6 +472,7 @@ class Var(Base, AdmObjMixin, ParamMixin, TypeUseMixin):
     init_ari = Column(PickleType)
     ''' Resolved and decoded ARI for ivar:`init_value`. '''
 
+
 class Sbr(Base, AdmObjMixin):
     ''' State Based Rule '''
     __tablename__ = "sbr"
@@ -496,6 +500,7 @@ class Sbr(Base, AdmObjMixin):
 
     max_count = Column(Integer)
     init_enabled = Column(Boolean)
+
 
 class Tbr(Base, AdmObjMixin):
     ''' Time Based Rule '''

--- a/tests/test_adm_yang.py
+++ b/tests/test_adm_yang.py
@@ -483,11 +483,13 @@ module example-empty {
     amm:enum 2;
     description
       "";
+    amm:abstract true;
   }
   amm:ident name2 {
     amm:enum 3;
     description
       "";
+    amm:abstract false;
     amm:base "./IDENT/name1";
   }
 ''',
@@ -496,11 +498,13 @@ module example-empty {
     amm:enum 1;
     description
       "one base";
+    amm:abstract true;
   }
   amm:ident base2 {
     amm:enum 2;
     description
       "other base";
+    amm:abstract true;
   }
   amm:ident derived {
     amm:enum 3;

--- a/tests/test_ari_text.py
+++ b/tests/test_ari_text.py
@@ -484,11 +484,11 @@ class TestAriText(unittest.TestCase):
     def test_ari_text_encode_objref_AM(self):
         TEST_CASE = [
             ("example", "adm", StructType.EDD, "myEDD", {
-                LiteralARI(value=True): 
-                LiteralARI(value=True, type_id=StructType.BOOL)}, 
+                LiteralARI(value=True):
+                LiteralARI(value=True, type_id=StructType.BOOL)},
                 "ari://example/adm/EDD/myEDD(true=/BOOL/true)"),
             (65535, 18, StructType.INT, "34", {
-                LiteralARI(value=101): 
+                LiteralARI(value=101):
                 ReferenceARI(
                     ident=Identity(type_id=StructType.INT, obj_id="11")
                 )},
@@ -1263,7 +1263,6 @@ class TestAriText(unittest.TestCase):
                 self.assertLess(0, loop.tell())
                 self.assertEqual(loop.getvalue(), text)
 
-
     def test_ari_AM_loopback(self):
         TEST_CASE = [
             ("ari://example/adm-a/CTRL/otherobj(true,3)"),
@@ -1378,7 +1377,6 @@ class TestAriText(unittest.TestCase):
             with self.subTest(text):
                 with self.assertRaises(ari_text.ParseError):
                     ari = dec.decode(io.StringIO(text))
-                    LOGGER.info('Got ARI %s', ari)
 
     def test_ari_text_decode_invalid(self):
         TEST_CASE = [
@@ -1401,5 +1399,5 @@ class TestAriText(unittest.TestCase):
         for row in TEST_CASE:
             text = row
             with self.subTest(text):
-                self.assertRaises(ari_text.ParseError, lambda: dec.decode(io.StringIO(text)))
-
+                with self.assertRaises(ari_text.ParseError):
+                    dec.decode(io.StringIO(text))


### PR DESCRIPTION
Allows users of the model (CAMP) to observe the abstract marking.

Related to #63