### PR TITLE
Decode invalid test cases

### DIFF
--- a/src/ace/typing.py
+++ b/src/ace/typing.py
@@ -33,6 +33,7 @@ from .ari import (
     DTN_EPOCH, StructType, Table,
     ARI, LiteralARI, ReferenceARI, Identity, is_undefined, NULL, TRUE
 )
+import struct
 
 LOGGER = logging.getLogger(__name__)
 
@@ -430,7 +431,6 @@ class AnyType(BuiltInType):
 
         return True
 
-
 LITERALS = {
     'null': NullType(),
     'bool': BoolType(),
@@ -440,11 +440,14 @@ LITERALS = {
     'vast': NumericType(StructType.VAST, -2 ** 63, 2 ** 63 - 1),
     'uvast': NumericType(StructType.UVAST, 0, 2 ** 64 - 1),
     # from: numpy.finfo(numpy.float32).max
-    # Reduce range that ACE is allowing to match that of the REFDA
-    'real32': NumericType(StructType.REAL32, -3.402823e+38, 3.402823e+38),
+    'real32': NumericType(StructType.REAL32, 
+                         struct.unpack('!f', bytes.fromhex('ff7fffff'))[0], 
+                         struct.unpack('!f', bytes.fromhex('7f7fffff'))[0]),
     # from: numpy.finfo(numpy.float32).max
+    #TODO: update real64 too like real32?
     'real64': NumericType(StructType.REAL64,
-                          -1.7976931348623157e+308, 1.7976931348623157e+308),
+                          struct.unpack('!d', bytes.fromhex('ffefffffffffffff'))[0], 
+                          struct.unpack('!d', bytes.fromhex('7fefffffffffffff'))[0]),
     'textstr': StringType(StructType.TEXTSTR),
     'bytestr': StringType(StructType.BYTESTR),
 

--- a/src/ace/typing.py
+++ b/src/ace/typing.py
@@ -440,8 +440,7 @@ LITERALS = {
     'vast': NumericType(StructType.VAST, -2 ** 63, 2 ** 63 - 1),
     'uvast': NumericType(StructType.UVAST, 0, 2 ** 64 - 1),
     # from: numpy.finfo(numpy.float32).max
-    # TODO: slightly reduce the range that ACE is allowing to match that of the REFDA
-    #'real32': NumericType(StructType.REAL32, -3.4028235e+38, 3.4028235e+38),
+    # Reduce range that ACE is allowing to match that of the REFDA
     'real32': NumericType(StructType.REAL32, -3.402823e+38, 3.402823e+38),
     # from: numpy.finfo(numpy.float32).max
     'real64': NumericType(StructType.REAL64,

--- a/src/ace/typing.py
+++ b/src/ace/typing.py
@@ -444,7 +444,6 @@ LITERALS = {
                          struct.unpack('!f', bytes.fromhex('ff7fffff'))[0], 
                          struct.unpack('!f', bytes.fromhex('7f7fffff'))[0]),
     # from: numpy.finfo(numpy.float32).max
-    #TODO: update real64 too like real32?
     'real64': NumericType(StructType.REAL64,
                           struct.unpack('!d', bytes.fromhex('ffefffffffffffff'))[0], 
                           struct.unpack('!d', bytes.fromhex('7fefffffffffffff'))[0]),

--- a/src/ace/typing.py
+++ b/src/ace/typing.py
@@ -440,7 +440,9 @@ LITERALS = {
     'vast': NumericType(StructType.VAST, -2 ** 63, 2 ** 63 - 1),
     'uvast': NumericType(StructType.UVAST, 0, 2 ** 64 - 1),
     # from: numpy.finfo(numpy.float32).max
-    'real32': NumericType(StructType.REAL32, -3.4028235e+38, 3.4028235e+38),
+    # TODO: slightly reduce the range that ACE is allowing to match that of the REFDA
+    #'real32': NumericType(StructType.REAL32, -3.4028235e+38, 3.4028235e+38),
+    'real32': NumericType(StructType.REAL32, -3.402823e+38, 3.402823e+38),
     # from: numpy.finfo(numpy.float32).max
     'real64': NumericType(StructType.REAL64,
                           -1.7976931348623157e+308, 1.7976931348623157e+308),

--- a/tests/test_ari_text.py
+++ b/tests/test_ari_text.py
@@ -1392,8 +1392,9 @@ class TestAriText(unittest.TestCase):
             ("ari:/VAST/-0x8FFFFFFFFFFFFFFF"),
             ("ari:/VAST/-0x1FFFFFFFFFFFFFFFF"),
             ("ari:/UVAST/-1"),
-            # FIXME: ("ari:/REAL32/-3.40282347E+38"),
-            # FIXME: ("ari:/REAL32/3.40282347E+38"),
+            # The range for C floats is -3.40282347E+38 to 3.40282347E+38
+            ("ari:/REAL32/-3.40282347E+38"), # Madeline -  fix for ACE #23
+            ("ari:/REAL32/3.40282347E+38"), # Madeline - fix for ACE #23
             ("ari:/EXECSET/N=1234;"),  # no targets
             ("ari:/RPTSET/n=null;r=725943845;"),  # no reports
         ]

--- a/tests/test_ari_text.py
+++ b/tests/test_ari_text.py
@@ -1392,9 +1392,8 @@ class TestAriText(unittest.TestCase):
             ("ari:/VAST/-0x8FFFFFFFFFFFFFFF"),
             ("ari:/VAST/-0x1FFFFFFFFFFFFFFFF"),
             ("ari:/UVAST/-1"),
-            # The range for C floats is -3.40282347E+38 to 3.40282347E+38
-            ("ari:/REAL32/-3.40282347E+38"), # Madeline -  fix for ACE #23
-            ("ari:/REAL32/3.40282347E+38"), # Madeline - fix for ACE #23
+            ("ari:/REAL32/-3.40282347E+38"),
+            ("ari:/REAL32/3.40282347E+38"),
             ("ari:/EXECSET/N=1234;"),  # no targets
             ("ari:/RPTSET/n=null;r=725943845;"),  # no reports
         ]


### PR DESCRIPTION
In order to get the two test cases in `test_ari_text_decode_invalid` to throw a ParseError and therefore pass, I needed to slightly reduce the range that ACE is allowing for the definition of a REAL32 literal, thus making it match what is found in the REFDA. The dtnma-tools repo uses the FLT_MAX and -FLT_MAX C macros from the standard `float.h` header file (as seen [here](https://github.com/JHUAPL-DTNMA/dtnma-tools/blob/apl-fy24/src/cace/amm/typing.c#L325)). According to [this site](https://en.cppreference.com/w/c/types/limits.html) which I used as my point of reference, the FLT_MAX should be 3.402823e+38 instead of 3.4028235.

All unit tests were passing for me once I made this change. 