### PR TITLE
No range for untyped integers

### DIFF
--- a/src/ace/ari.py
+++ b/src/ace/ari.py
@@ -27,12 +27,16 @@ import datetime
 from dataclasses import dataclass
 import enum
 import math
+import portion
 from typing import Callable, Dict, List, Optional, Tuple, Union
 import cbor2
 import numpy
 
 DTN_EPOCH = numpy.datetime64("2000-01-01T00:00:00")
 ''' Reference for absolute time points '''
+
+INT_ENVELOPE = portion.closedopen(-(2 ** 63), 2 ** 64)
+''' Envelope for union of all valid integer types '''
 
 
 def _is_nan(val) -> bool:

--- a/src/ace/ari_cbor.py
+++ b/src/ace/ari_cbor.py
@@ -28,7 +28,7 @@ import numpy
 from typing import BinaryIO
 import cbor2
 from ace.ari import (
-    DTN_EPOCH, ARI, Identity, ReferenceARI, LiteralARI, StructType,
+    DTN_EPOCH, INT_ENVELOPE, ARI, Identity, ReferenceARI, LiteralARI, StructType,
     Table, ExecutionSet, ReportSet, Report
 )
 from ace.typing import BUILTINS_BY_ENUM, NONCE
@@ -197,7 +197,12 @@ class Decoder:
                 reports=rpts
             )
         else:
+            # any other type or untyped primitive value
             value = item
+            if isinstance(value, int):
+                if not value in INT_ENVELOPE:
+                    raise ValueError(f"Integer value {value} is outside valid envelope {INT_ENVELOPE}")
+
         return value
 
     def _item_to_timeval(self, item) -> numpy.timedelta64:

--- a/src/ace/ari_text/parsemod.py
+++ b/src/ace/ari_text/parsemod.py
@@ -61,12 +61,19 @@ def p_ssp_primitive(p):
     'ssp : VALSEG'
     try:
         value = util.PRIMITIVE(p[1])
+        
+        # Add validation for 64-bit signed integer range
+        min_int64 = -0x8000000000000000
+        max_int64 = 0x7FFFFFFFFFFFFFFF
+        
+        if not min_int64 <= value <= max_int64:
+            raise ari_text.ParseError(f"Value {value} is outside valid 64-bit integer range [{min_int64}, {max_int64}]")
+            
     except Exception as err:
         LOGGER.error('Primitive value invalid: %s', err)
-        raise RuntimeError(err) from err
-    p[0] = LiteralARI(
-        value=value,
-    )
+        raise ari_text.ParseError(f'Invalid primitive value: {err}') from err
+    
+    p[0] = LiteralARI(value=value)
 
 
 def p_ssp_typedlit(p):

--- a/src/ace/ari_text/parsemod.py
+++ b/src/ace/ari_text/parsemod.py
@@ -66,23 +66,6 @@ def p_ssp_primitive(p):
     p[0] = LiteralARI(
         value=value,
     )
-'''def p_ssp_primitive(p):
-    'ssp : VALSEG'
-    try:
-        value = util.PRIMITIVE(p[1])
-        
-        # Add validation for 64-bit signed integer range
-        min_int64 = -0x8000000000000000
-        max_int64 = 0x7FFFFFFFFFFFFFFF
-        
-        if not min_int64 <= value <= max_int64:
-            raise ari_text.ParseError(f"Value {value} is outside valid 64-bit integer range [{min_int64}, {max_int64}]")
-            
-    except Exception as err:
-        LOGGER.error('Primitive value invalid: %s', err)
-        raise RuntimeError(err) from err
-    
-    p[0] = LiteralARI(value=value)'''
 
 
 def p_ssp_typedlit(p):

--- a/src/ace/ari_text/parsemod.py
+++ b/src/ace/ari_text/parsemod.py
@@ -71,7 +71,7 @@ def p_ssp_primitive(p):
             
     except Exception as err:
         LOGGER.error('Primitive value invalid: %s', err)
-        raise ari_text.ParseError(f'Invalid primitive value: {err}') from err
+        raise RuntimeError(err) from err
     
     p[0] = LiteralARI(value=value)
 

--- a/src/ace/ari_text/parsemod.py
+++ b/src/ace/ari_text/parsemod.py
@@ -56,8 +56,17 @@ def p_ari_noscheme(p):
     p[0] = p[1]
 
 # The following are untyped literals with primitive values
-
 def p_ssp_primitive(p):
+    'ssp : VALSEG'
+    try:
+        value = util.PRIMITIVE(p[1])
+    except Exception as err:
+        LOGGER.error('Primitive value invalid: %s', err)
+        raise RuntimeError(err) from err
+    p[0] = LiteralARI(
+        value=value,
+    )
+'''def p_ssp_primitive(p):
     'ssp : VALSEG'
     try:
         value = util.PRIMITIVE(p[1])
@@ -73,7 +82,7 @@ def p_ssp_primitive(p):
         LOGGER.error('Primitive value invalid: %s', err)
         raise RuntimeError(err) from err
     
-    p[0] = LiteralARI(value=value)
+    p[0] = LiteralARI(value=value)'''
 
 
 def p_ssp_typedlit(p):

--- a/src/ace/ari_text/util.py
+++ b/src/ace/ari_text/util.py
@@ -29,7 +29,7 @@ import re
 from typing import List
 import numpy
 import cbor_diag
-from ace.ari import UNDEFINED, StructType
+from ace.ari import INT_ENVELOPE, UNDEFINED, StructType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -105,11 +105,9 @@ def t_floathex(found):
 def t_int(found):
     value = int(found[0], 0)
 
-    lower_bound = -(2 ** 63)
-    upper_bound = 2 ** 64 - 1
-    if not lower_bound <= value <= upper_bound:
-        raise ValueError(f"Integer value {value} is outside valid range [{lower_bound}, {upper_bound}]")
-    
+    if not value in INT_ENVELOPE:
+        raise ValueError(f"Integer value {value} is outside valid envelope {INT_ENVELOPE}")
+
     return value
 
 

--- a/src/ace/ari_text/util.py
+++ b/src/ace/ari_text/util.py
@@ -104,12 +104,21 @@ def t_floathex(found):
 '''@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
 def t_int(found):
     return int(found[0], 0)'''
-@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0xX][0-9a-fA-F]+|\d+)')  # Fixed regex pattern
+@TypeMatch.apply(r'[+-]?((\d+)|(0[xX][0-9a-fA-F]+)|(0[bB][01]+))')
 def t_int(found):
-    num_str = found[0] # Parse the number first
+    num_str = found[0]
     
-    # Convert to integer using base 0 for automatic base detection
-    parsed_num = int(num_str, 0)
+    # Determine base based on prefix
+    if num_str.lower().startswith(('0b','+0b')):
+        base = 2
+    elif num_str.lower().startswith(('0x','-0x')):
+        base = 16
+    elif num_str.lower().startswith(('+0X10')):
+        base = 10
+    else:
+        base = 10
+    
+    parsed_num = int(num_str, base)
     
     lower_bound = -(2 ** 63)
     upper_bound = 2 ** 64 - 1

--- a/src/ace/ari_text/util.py
+++ b/src/ace/ari_text/util.py
@@ -103,8 +103,11 @@ def t_floathex(found):
 # int is decimal, binary, or hexadecimal
 '''@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
 def t_int(found):
-    return int(found[0], 0)'''
-@TypeMatch.apply(r'[+-]?((\d+)|(0[xX][0-9a-fA-F]+)|(0[bB][01]+))')
+    return int(found[0], 0)
+#@TypeMatch.apply(r'[+-]?((\d+)|(0[xX][0-9a-fA-F]+)|(0[bB][01]+))')
+
+@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
+#@TypeMatch.apply(r'[+-]?((\d+)|(0[xX][0-9a-fA-F]+)|(0[bB][01]+))')
 def t_int(found):
     num_str = found[0]
     
@@ -113,8 +116,6 @@ def t_int(found):
         base = 2
     elif num_str.lower().startswith(('0x','-0x')):
         base = 16
-    elif num_str.lower().startswith(('+0X10')):
-        base = 10
     else:
         base = 10
     
@@ -123,6 +124,31 @@ def t_int(found):
     lower_bound = -(2 ** 63)
     upper_bound = 2 ** 64 - 1
     
+    if not lower_bound <= parsed_num <= upper_bound:
+        raise ValueError(f"Integer value {parsed_num} is outside valid range [{lower_bound}, {upper_bound}]")
+    
+    return parsed_num'''
+@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
+def t_int(found):
+    num_str = found[0]
+    # Remove leading '+' or '-' sign if present (only for hex numbers)
+    if num_str.lower().startswith(('0x', '+0x', '-0x')):
+        num_str = '0x' + num_str[2:]
+    elif num_str.lower().startswith(('0b', '+0b', '-0b')):
+        num_str = '0b' + num_str[2:]
+    
+    # Determine base based on prefix
+    if num_str.lower().startswith(('0b')):
+        base = 2
+    elif num_str.lower().startswith(('0x')):
+        base = 16
+    else:
+        base = 10
+    
+    parsed_num = int(num_str, base)
+    
+    lower_bound = -(2 ** 63)
+    upper_bound = 2 ** 64 - 1
     if not lower_bound <= parsed_num <= upper_bound:
         raise ValueError(f"Integer value {parsed_num} is outside valid range [{lower_bound}, {upper_bound}]")
     

--- a/src/ace/ari_text/util.py
+++ b/src/ace/ari_text/util.py
@@ -101,58 +101,16 @@ def t_floathex(found):
 
 
 # int is decimal, binary, or hexadecimal
-'''@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
+@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
 def t_int(found):
-    return int(found[0], 0)
-#@TypeMatch.apply(r'[+-]?((\d+)|(0[xX][0-9a-fA-F]+)|(0[bB][01]+))')
+    value = int(found[0], 0)
 
-@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
-#@TypeMatch.apply(r'[+-]?((\d+)|(0[xX][0-9a-fA-F]+)|(0[bB][01]+))')
-def t_int(found):
-    num_str = found[0]
-    
-    # Determine base based on prefix
-    if num_str.lower().startswith(('0b','+0b')):
-        base = 2
-    elif num_str.lower().startswith(('0x','-0x')):
-        base = 16
-    else:
-        base = 10
-    
-    parsed_num = int(num_str, base)
-    
     lower_bound = -(2 ** 63)
     upper_bound = 2 ** 64 - 1
+    if not lower_bound <= value <= upper_bound:
+        raise ValueError(f"Integer value {value} is outside valid range [{lower_bound}, {upper_bound}]")
     
-    if not lower_bound <= parsed_num <= upper_bound:
-        raise ValueError(f"Integer value {parsed_num} is outside valid range [{lower_bound}, {upper_bound}]")
-    
-    return parsed_num'''
-@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
-def t_int(found):
-    num_str = found[0]
-    # Remove leading '+' or '-' sign if present (only for hex numbers)
-    if num_str.lower().startswith(('0x', '+0x', '-0x')):
-        num_str = '0x' + num_str[2:]
-    elif num_str.lower().startswith(('0b', '+0b', '-0b')):
-        num_str = '0b' + num_str[2:]
-    
-    # Determine base based on prefix
-    if num_str.lower().startswith(('0b')):
-        base = 2
-    elif num_str.lower().startswith(('0x')):
-        base = 16
-    else:
-        base = 10
-    
-    parsed_num = int(num_str, base)
-    
-    lower_bound = -(2 ** 63)
-    upper_bound = 2 ** 64 - 1
-    if not lower_bound <= parsed_num <= upper_bound:
-        raise ValueError(f"Integer value {parsed_num} is outside valid range [{lower_bound}, {upper_bound}]")
-    
-    return parsed_num
+    return value
 
 
 @TypeMatch.apply(r'!?[a-zA-Z_][a-zA-Z0-9_\-\.]*')

--- a/src/ace/ari_text/util.py
+++ b/src/ace/ari_text/util.py
@@ -101,9 +101,23 @@ def t_floathex(found):
 
 
 # int is decimal, binary, or hexadecimal
-@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
+'''@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0-9a-fA-F]+|\d+)')
 def t_int(found):
-    return int(found[0], 0)
+    return int(found[0], 0)'''
+@TypeMatch.apply(r'[+-]?(0[bB][01]+|0[xX][0xX][0-9a-fA-F]+|\d+)')  # Fixed regex pattern
+def t_int(found):
+    num_str = found[0] # Parse the number first
+    
+    # Convert to integer using base 0 for automatic base detection
+    parsed_num = int(num_str, 0)
+    
+    lower_bound = -(2 ** 63)
+    upper_bound = 2 ** 64 - 1
+    
+    if not lower_bound <= parsed_num <= upper_bound:
+        raise ValueError(f"Integer value {parsed_num} is outside valid range [{lower_bound}, {upper_bound}]")
+    
+    return parsed_num
 
 
 @TypeMatch.apply(r'!?[a-zA-Z_][a-zA-Z0-9_\-\.]*')

--- a/tests/test_ari_text.py
+++ b/tests/test_ari_text.py
@@ -1337,9 +1337,6 @@ class TestAriText(unittest.TestCase):
 
     def test_ari_text_decode_failure(self):
         TEST_CASE = [
-            # madeline - fix for ACE #21
-            # Both are less than -0x8000000000000000 which
-            # is the minimum value for a 64-bit integer
             ("-0x8FFFFFFFFFFFFFFF"),
             ("-0x1FFFFFFFFFFFFFFFF"),
             ("ari:/OTHERNAME/0"),

--- a/tests/test_ari_text.py
+++ b/tests/test_ari_text.py
@@ -1337,8 +1337,11 @@ class TestAriText(unittest.TestCase):
 
     def test_ari_text_decode_failure(self):
         TEST_CASE = [
-            # FIXME: ("-0x8FFFFFFFFFFFFFFF"),
-            # FIXME: ("-0x1FFFFFFFFFFFFFFFF"),
+            # madeline - fix for ACE #21
+            # Both are less than -0x8000000000000000 which
+            # is the minimum value for a 64-bit integer
+            ("-0x8FFFFFFFFFFFFFFF"),
+            ("-0x1FFFFFFFFFFFFFFFF"),
             ("ari:/OTHERNAME/0"),
             ("ari:/UNDEFINED/undefined"),
             ("ari:/NULL/fae"),


### PR DESCRIPTION
The test cases `("-0x8FFFFFFFFFFFFFFF")` and `("-0x1FFFFFFFFFFFFFFFF")` are supposed to fail because both are less than `-0x8000000000000000` which is the minimum value for a 64-bit integer