### PR TITLE
Be more strict about literal primitive value types

### DIFF
--- a/src/ace/adm_yang.py
+++ b/src/ace/adm_yang.py
@@ -482,13 +482,17 @@ class Decoder:
                         typeobj=self._get_typeobj(param_stmt)
                     )
 
-                    def_stmt = param_stmt.search_one((AMM_MOD, 'default'))
-                    if def_stmt:
-                        item.default_value = def_stmt.arg
-                        # actually check the content
-                        item.default_ari = self._get_ari(def_stmt.arg)
-                        if item.typeobj.get(item.default_ari) is not None:
-                            item.default_ari = item.typeobj.convert(item.default_ari)
+                    try:
+                        def_stmt = param_stmt.search_one((AMM_MOD, 'default'))
+                        if def_stmt:
+                            item.default_value = def_stmt.arg
+                            # actually check the content
+                            item.default_ari = self._get_ari(def_stmt.arg)
+                            if item.typeobj.get(item.default_ari) is not None:
+                                item.default_ari = item.typeobj.convert(item.default_ari)
+                    except Exception as err:
+                        raise RuntimeError(f'Failure in default value "{def_stmt.arg}": {err}') from err
+
                 except Exception as err:
                     raise RuntimeError(f'Failure handling parameter "{param_stmt.arg}": {err}') from err
 

--- a/src/ace/ari.py
+++ b/src/ace/ari.py
@@ -23,6 +23,7 @@
 ''' The logical data model for an ARI and associated AMP data.
 This is distinct from the ORM in :mod:`models` used for ADM introspection.
 '''
+import copy
 import datetime
 from dataclasses import dataclass, field
 import enum
@@ -226,7 +227,8 @@ class LiteralARI(ARI):
 
             def func(item): return item.visit(visitor)
 
-            numpy.vectorize(func)(self.value)
+            if self.value.size > 0:
+                numpy.vectorize(func)(self.value)
         super().visit(visitor)
 
     def map(self, func: Callable[['ARI'], 'ARI']) -> 'ARI':
@@ -246,7 +248,11 @@ class LiteralARI(ARI):
             result = LiteralARI(rvalue, self.type_id)
 
         elif isinstance(self.value, Table):
-            rvalue = numpy.vectorize(lfunc)(self.value)
+            if self.value.size > 0:
+                rvalue = numpy.vectorize(lfunc)(self.value)
+            else:
+                # preserve column count
+                rvalue = copy.copy(self.value)
             result = LiteralARI(rvalue, self.type_id)
 
         elif isinstance(self.value, ExecutionSet):


### PR DESCRIPTION
This adds two `ari` module types to help literal value users.

Closes #107 