### PR TITLE
Relocate value-type checking from ADM loader to constraint

### DIFF
--- a/src/ace/adm_yang.py
+++ b/src/ace/adm_yang.py
@@ -491,10 +491,8 @@ class Decoder:
                         def_stmt = param_stmt.search_one((AMM_MOD, 'default'))
                         if def_stmt:
                             item.default_value = def_stmt.arg
-                            # actually check the content
+                            # actually check the syntax
                             item.default_ari = self._get_ari(def_stmt.arg)
-                            if item.typeobj.get(item.default_ari) is not None:
-                                item.default_ari = item.typeobj.convert(item.default_ari)
                     except Exception as err:
                         raise RuntimeError(f'Failure in default value "{def_stmt.arg}": {err}') from err
 
@@ -530,10 +528,8 @@ class Decoder:
             value_stmt = stmt.search_one((AMM_MOD, 'init-value'))
             if value_stmt:
                 obj.init_value = value_stmt.arg
-                # actually check the content
+                # actually check the syntax
                 obj.init_ari = self._get_ari(value_stmt.arg)
-                if obj.typeobj.get(obj.init_ari) is not None:
-                    obj.init_ari = obj.typeobj.convert(obj.init_ari)
             elif cls is Const:
                 LOGGER.warning('const "%s" is missing init-value substatement', stmt.arg)
 

--- a/src/ace/constraints/basic.py
+++ b/src/ace/constraints/basic.py
@@ -168,7 +168,8 @@ class valid_type_name:  # pylint: disable=invalid-name
             count += self(issuelist, obj, *args, **kwargs)
         return count
 
-    def _check_typeobj(self, issuelist: List[Issue], top_obj, ctr: models.TypeUseMixin, db_sess: orm.Session, adm: models.AdmModule):
+    def _check_typeobj(self, issuelist: List[Issue], top_obj, ctr: models.TypeUseMixin,
+                       db_sess: orm.Session, adm: models.AdmModule):
         ''' Verify a single named type. '''
         typeobj = ctr.typeobj
         if not typeobj:
@@ -196,7 +197,8 @@ class valid_reference_ari:  # pylint: disable=invalid-name
     :py:cls:`valid_type_name` so not handled here.
     '''
 
-    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session, top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
+    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session,
+                 top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
         ''' Entrypoint for this functor. '''
         count = 0
         if isinstance(obj, models.AdmModule):
@@ -216,16 +218,16 @@ class valid_reference_ari:  # pylint: disable=invalid-name
 
         if isinstance(obj, (models.Const, models.Var)):
             # actual check on init value
-            count += self._do_check(issuelist, obj.init_value, obj.init_ari, obj, adm, db_sess)
+            count += self._do_check(issuelist, obj.init_value, obj.init_ari, obj, db_sess)
         elif isinstance(obj, models.Sbr):
-            count += self._do_check(issuelist, obj.action_value, obj.action_ari, obj, adm, db_sess)
-            count += self._do_check(issuelist, obj.condition_value, obj.condition_ari, obj, adm, db_sess)
+            count += self._do_check(issuelist, obj.action_value, obj.action_ari, obj, db_sess)
+            count += self._do_check(issuelist, obj.condition_value, obj.condition_ari, obj, db_sess)
         elif isinstance(obj, models.Tbr):
-            count += self._do_check(issuelist, obj.action_value, obj.action_ari, obj, adm, db_sess)
+            count += self._do_check(issuelist, obj.action_value, obj.action_ari, obj, db_sess)
 
         if isinstance(obj, models.TypeNameItem):
             # actual check on default
-            count += self._do_check(issuelist, obj.default_value, obj.default_ari, top_obj, adm, db_sess)
+            count += self._do_check(issuelist, obj.default_value, obj.default_ari, top_obj, db_sess)
 
         return count
 
@@ -235,7 +237,8 @@ class valid_reference_ari:  # pylint: disable=invalid-name
             count += self(issuelist, obj, *args, **kwargs)
         return count
 
-    def _do_check(self, issuelist: List[Issue], _value: str, val_ari: Optional[ari.ARI], top_obj: models.AdmObjMixin, adm: models.AdmModule, db_sess: orm.Session) -> int:
+    def _do_check(self, issuelist: List[Issue], _value: str, val_ari: Optional[ari.ARI],
+                  top_obj: models.AdmObjMixin, db_sess: orm.Session) -> int:
         ''' Walk the ARI for any internal references '''
         if val_ari is None:
             return 0
@@ -264,7 +267,8 @@ class default_value_type_match:  # pylint: disable=invalid-name
     for Const and Var objects.
     '''
 
-    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session, top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
+    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session,
+                 top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
         ''' Entrypoint for this functor. '''
         count = 0
         if isinstance(obj, models.AdmModule):
@@ -298,7 +302,8 @@ class default_value_type_match:  # pylint: disable=invalid-name
             count += self(issuelist, obj, db_sess, top_obj=obj, adm=adm)
         return count
 
-    def _do_check(self, issuelist: List[Issue], value: str, val_ari: Optional[ari.ARI], typeobj: typing.BaseType, top_obj: models.AdmObjMixin, adm: models.AdmModule) -> int:
+    def _do_check(self, issuelist: List[Issue], value: str, val_ari: Optional[ari.ARI],
+                  typeobj: typing.BaseType, top_obj: models.AdmObjMixin, adm: models.AdmModule) -> int:
         ''' Check the root ARI against its needed type '''
         if val_ari is None:
             return 0

--- a/src/ace/constraints/basic.py
+++ b/src/ace/constraints/basic.py
@@ -235,7 +235,7 @@ class valid_reference_ari:  # pylint: disable=invalid-name
             count += self(issuelist, obj, *args, **kwargs)
         return count
 
-    def _do_check(self, issuelist:List[Issue], _value: str, val_ari: Optional[ari.ARI], top_obj:models.AdmObjMixin, adm:models.AdmModule, db_sess: orm.Session) -> int:
+    def _do_check(self, issuelist: List[Issue], _value: str, val_ari: Optional[ari.ARI], top_obj: models.AdmObjMixin, adm: models.AdmModule, db_sess: orm.Session) -> int:
         ''' Walk the ARI for any internal references '''
         if val_ari is None:
             return 0
@@ -277,8 +277,8 @@ class default_value_type_match:  # pylint: disable=invalid-name
             count += self._iter_call(issuelist, obj.var, db_sess, adm=obj)
 
         if isinstance(obj, models.ParamMixin) and obj.parameters:
-                for param in obj.parameters.items:
-                    count += self(issuelist, param, db_sess, top_obj=obj, adm=adm)
+            for param in obj.parameters.items:
+                count += self(issuelist, param, db_sess, top_obj=obj, adm=adm)
 
         if isinstance(obj, models.Ctrl):
             count += self(issuelist, obj.result, db_sess, top_obj=obj, adm=adm)
@@ -292,13 +292,13 @@ class default_value_type_match:  # pylint: disable=invalid-name
 
         return count
 
-    def _iter_call(self, issuelist:List[Issue], container: Iterable, db_sess: orm.Session, adm) -> int:
+    def _iter_call(self, issuelist: List[Issue], container: Iterable, db_sess: orm.Session, adm) -> int:
         count = 0
         for obj in container:
             count += self(issuelist, obj, db_sess, top_obj=obj, adm=adm)
         return count
 
-    def _do_check(self, issuelist:List[Issue], value: str, val_ari: Optional[ari.ARI], typeobj: typing.BaseType, top_obj:models.AdmObjMixin, adm:models.AdmModule) -> int:
+    def _do_check(self, issuelist: List[Issue], value: str, val_ari: Optional[ari.ARI], typeobj: typing.BaseType, top_obj: models.AdmObjMixin, adm: models.AdmModule) -> int:
         ''' Check the root ARI against its needed type '''
         if val_ari is None:
             return 0

--- a/src/ace/constraints/basic.py
+++ b/src/ace/constraints/basic.py
@@ -25,8 +25,8 @@
 import logging
 import os
 from sqlalchemy import inspect, orm, func
-from typing import Optional
-from ace import models, ari
+from typing import Iterable, Optional, List
+from ace import models, ari, typing
 from ace.lookup import dereference, TypeResolver, TypeResolverError
 from .core import register, Issue
 
@@ -34,7 +34,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @register
-def minimal_metadata(issuelist, obj, db_sess):  # pylint: disable=invalid-name
+def minimal_metadata(issuelist: List[Issue], obj: object, db_sess: orm.Session):  # pylint: disable=invalid-name
     ''' Ensure an ADM contains minimum content. '''
     count = 0
     if obj is None:
@@ -56,7 +56,7 @@ class unique_adm_names:  # pylint: disable=invalid-name
 
     is_global = True
 
-    def __call__(self, issuelist, obj, db_sess):
+    def __call__(self, issuelist: List[Issue], _obj: object, db_sess: orm.Session):
         count = 0
         attr = models.AdmModule.norm_name
 
@@ -80,7 +80,7 @@ class unique_adm_names:  # pylint: disable=invalid-name
 
 
 @register
-def same_file_name(issuelist, obj, _db_sess):
+def same_file_name(issuelist: List[Issue], obj: object, _db_sess: orm.Session):
     ''' Ensure an ADM name matches its source file name. '''
     if isinstance(obj, models.AdmModule):
         if obj.source.abs_file_path is None:
@@ -112,7 +112,7 @@ class unique_object_names:  # pylint: disable=invalid-name
         LOGGER.debug('UniqueNames checking sets in: %s',
                      ', '.join(self._list_attrs))
 
-    def __call__(self, issuelist, obj, _db_sess):
+    def __call__(self, issuelist: List[Issue], obj: object, _db_sess: orm.Session):
         count = 0
         if isinstance(obj, models.AdmModule):
             for list_name in self._list_attrs:
@@ -139,7 +139,7 @@ class unique_object_names:  # pylint: disable=invalid-name
 class valid_type_name:  # pylint: disable=invalid-name
     ''' Ensure that all type names are well-fromed, but not necessarily valid in the context. '''
 
-    def __call__(self, issuelist, obj, db_sess, adm=None):
+    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session, adm=None):
         ''' Entrypoint for this functor. '''
         count = 0
         if isinstance(obj, models.AdmModule):
@@ -150,11 +150,8 @@ class valid_type_name:  # pylint: disable=invalid-name
             count += self._iter_call(issuelist, obj.oper, db_sess, adm=obj)
             count += self._iter_call(issuelist, obj.sbr, db_sess, adm=obj)
             count += self._iter_call(issuelist, obj.tbr, db_sess, adm=obj)
-        elif isinstance(obj, models.Const):
-            count += self._check_typeobj(issuelist, obj, obj, db_sess, adm)
-        elif isinstance(obj, models.Edd):
-            count += self._check_typeobj(issuelist, obj, obj, db_sess, adm)
-        elif isinstance(obj, models.Var):
+
+        if isinstance(obj, (models.Const, models.Edd, models.Var)):
             count += self._check_typeobj(issuelist, obj, obj, db_sess, adm)
         elif isinstance(obj, models.Ctrl):
             if obj.result:
@@ -165,13 +162,13 @@ class valid_type_name:  # pylint: disable=invalid-name
                 count += self._check_typeobj(issuelist, obj, operand, db_sess, adm)
         return count
 
-    def _iter_call(self, issuelist, container, *args, **kwargs):
+    def _iter_call(self, issuelist: List[Issue], container, *args, **kwargs):
         count = 0
         for obj in container:
             count += self(issuelist, obj, *args, **kwargs)
         return count
 
-    def _check_typeobj(self, issuelist, top_obj, ctr: models.TypeUseMixin, db_sess, adm: models.AdmModule):
+    def _check_typeobj(self, issuelist: List[Issue], top_obj, ctr: models.TypeUseMixin, db_sess: orm.Session, adm: models.AdmModule):
         ''' Verify a single named type. '''
         typeobj = ctr.typeobj
         if not typeobj:
@@ -194,89 +191,131 @@ class valid_type_name:  # pylint: disable=invalid-name
 
 @register
 class valid_reference_ari:  # pylint: disable=invalid-name
-    ''' Ensure that all ARIs embedded within ADMs point to real objects. '''
+    ''' Ensure that all ARIs embedded within ADMs point to real objects.
+    Type references in TypeUseMixin are handled separately by the constraint
+    :py:cls:`valid_type_name` so not handled here.
+    '''
 
-    def __call__(self, issuelist, obj, db_sess, top_obj=None):
+    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session, top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
         ''' Entrypoint for this functor. '''
         count = 0
         if isinstance(obj, models.AdmModule):
-            count += self._iter_call(issuelist, obj.const, db_sess)
-            count += self._iter_call(issuelist, obj.var, db_sess)
-        elif isinstance(obj, (models.Const, models.Var)):
-            if obj.init_ari is not None:
+            # object types which have parameters or embedded ARIs, but not type use
+            count += self._iter_call(issuelist, obj.ident, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.const, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.ctrl, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.edd, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.oper, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.var, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.sbr, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.tbr, db_sess, adm=obj)
 
-                def checker(val):
-                    if not isinstance(val, ari.ReferenceARI):
-                        return
-                    if dereference(val, db_sess) is None:
-                        issuelist.append(Issue(
-                            obj=obj,
-                            detail=(
-                                f'Within the object named "{obj.name}" '
-                                f'the reference ARI for {val.ident} is not resolvable'
-                            ),
-                        ))
+        if isinstance(obj, models.ParamMixin) and obj.parameters:
+            for param in obj.parameters.items:
+                count += self(issuelist, param, db_sess, top_obj=obj, adm=adm)
 
-                obj.init_ari.visit(checker)
-            count += 1
+        if isinstance(obj, (models.Const, models.Var)):
+            # actual check on init value
+            count += self._do_check(issuelist, obj.init_value, obj.init_ari, obj, adm, db_sess)
+        elif isinstance(obj, models.Sbr):
+            count += self._do_check(issuelist, obj.action_value, obj.action_ari, obj, adm, db_sess)
+            count += self._do_check(issuelist, obj.condition_value, obj.condition_ari, obj, adm, db_sess)
+        elif isinstance(obj, models.Tbr):
+            count += self._do_check(issuelist, obj.action_value, obj.action_ari, obj, adm, db_sess)
+
+        if isinstance(obj, models.TypeNameItem):
+            # actual check on default
+            count += self._do_check(issuelist, obj.default_value, obj.default_ari, top_obj, adm, db_sess)
+
         return count
 
-    def _iter_call(self, issuelist, container, *args, **kwargs):
+    def _iter_call(self, issuelist: List[Issue], container, *args, **kwargs) -> int:
         count = 0
         for obj in container:
             count += self(issuelist, obj, *args, **kwargs)
         return count
 
+    def _do_check(self, issuelist:List[Issue], _value: str, val_ari: Optional[ari.ARI], top_obj:models.AdmObjMixin, adm:models.AdmModule, db_sess: orm.Session) -> int:
+        ''' Walk the ARI for any internal references '''
+        if val_ari is None:
+            return 0
+
+        def checker(val):
+            if not isinstance(val, ari.ReferenceARI):
+                return
+            if dereference(val, db_sess) is None:
+                issuelist.append(Issue(
+                    obj=top_obj,
+                    detail=(
+                        f'Within the object named "{top_obj.name}" '
+                        f'the reference ARI for {val.ident} is not resolvable'
+                    ),
+                ))
+
+        val_ari.visit(checker)
+        return 1
+
 
 @register
 class default_value_type_match:  # pylint: disable=invalid-name
-    ''' Ensure that all ARIs as default values actually match their
+    ''' Ensure that all ARIs as default or initial values actually match their
     associated type.
-    Default values are contained in object parameters
+    Default values are contained in object parameters, initial values are
+    for Const and Var objects.
     '''
 
-    def __call__(self, issuelist, obj, db_sess, top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
+    def __call__(self, issuelist: List[Issue], obj: object, db_sess: orm.Session, top_obj: Optional[models.AdmObjMixin] = None, adm: Optional[models.AdmModule] = None):
         ''' Entrypoint for this functor. '''
         count = 0
         if isinstance(obj, models.AdmModule):
-            # object types which have parameters
+            # object types which have parameters or init values
             count += self._iter_call(issuelist, obj.ident, db_sess, adm=obj)
             count += self._iter_call(issuelist, obj.const, db_sess, adm=obj)
-            count += self._iter_call(issuelist, obj.var, db_sess, adm=obj)
             count += self._iter_call(issuelist, obj.ctrl, db_sess, adm=obj)
+            count += self._iter_call(issuelist, obj.edd, db_sess, adm=obj)
             count += self._iter_call(issuelist, obj.oper, db_sess, adm=obj)
-        if isinstance(obj, models.ParamMixin):
-            if obj.parameters:
+            count += self._iter_call(issuelist, obj.var, db_sess, adm=obj)
+
+        if isinstance(obj, models.ParamMixin) and obj.parameters:
                 for param in obj.parameters.items:
                     count += self(issuelist, param, db_sess, top_obj=obj, adm=adm)
+
         if isinstance(obj, models.Ctrl):
             count += self(issuelist, obj.result, db_sess, top_obj=obj, adm=adm)
-        elif isinstance(obj, models.TypeNameItem):
-            # actual check
-            if obj.default_ari is not None:
+        elif isinstance(obj, (models.Const, models.Var)):
+            # actual check on init-value
+            count += self._do_check(issuelist, obj.init_value, obj.init_ari, obj.typeobj, obj, adm)
 
-                try:
-                    TypeResolver().resolve(obj.typeobj, adm)
-                except TypeResolverError:
-                    # treat as separate error
-                    pass
-
-                if obj.typeobj.get(obj.default_ari) is None:
-                    issuelist.append(Issue(
-                        obj=top_obj,
-                        detail=(
-                            f'Within the object named "{top_obj.name}" '
-                            f'the default value "{obj.default_value}" does not match '
-                            f'the associated type'
-                        ),
-                    ))
-
-            count += 1
+        if isinstance(obj, models.TypeNameItem):
+            # actual check on default
+            count += self._do_check(issuelist, obj.default_value, obj.default_ari, obj.typeobj, top_obj, adm)
 
         return count
 
-    def _iter_call(self, issuelist, container, db_sess, adm):
+    def _iter_call(self, issuelist:List[Issue], container: Iterable, db_sess: orm.Session, adm) -> int:
         count = 0
         for obj in container:
             count += self(issuelist, obj, db_sess, top_obj=obj, adm=adm)
         return count
+
+    def _do_check(self, issuelist:List[Issue], value: str, val_ari: Optional[ari.ARI], typeobj: typing.BaseType, top_obj:models.AdmObjMixin, adm:models.AdmModule) -> int:
+        ''' Check the root ARI against its needed type '''
+        if val_ari is None:
+            return 0
+
+        try:
+            TypeResolver().resolve(typeobj, adm)
+        except TypeResolverError:
+            # treat as separate error
+            pass
+
+        if typeobj.get(val_ari) is None:
+            issuelist.append(Issue(
+                obj=top_obj,
+                detail=(
+                    f'Within the object named "{top_obj.name}" '
+                    f'the value "{value}" does not match '
+                    f'the associated type'
+                ),
+            ))
+        return 1

--- a/src/ace/constraints/core.py
+++ b/src/ace/constraints/core.py
@@ -24,6 +24,7 @@
 '''
 from dataclasses import dataclass
 import logging
+from typing import Callable, List
 from ace import models
 
 LOGGER = logging.getLogger(__name__)
@@ -110,7 +111,7 @@ class Checker:
                     check_count, len(allissues))
         return allissues
 
-    def _add_result(self, issuelist, check_count, cst_name, cst, adm):
+    def _add_result(self, issuelist: List[Issue], check_count: int, cst_name:str, cst:Callable, adm: models.AdmModule):
         LOGGER.debug('Running constraint check: %s', cst_name)
         count = cst(issuelist, adm, self._db_sess) or 0
         check_count += count

--- a/src/ace/constraints/core.py
+++ b/src/ace/constraints/core.py
@@ -111,7 +111,7 @@ class Checker:
                     check_count, len(allissues))
         return allissues
 
-    def _add_result(self, issuelist: List[Issue], check_count: int, cst_name:str, cst:Callable, adm: models.AdmModule):
+    def _add_result(self, issuelist: List[Issue], check_count: int, cst_name: str, cst: Callable, adm: models.AdmModule):
         LOGGER.debug('Running constraint check: %s', cst_name)
         count = cst(issuelist, adm, self._db_sess) or 0
         check_count += count

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -294,5 +294,5 @@ class TestConstraintsBasic(BaseTest):
             module_name='example-adm-a',
             check_name='ace.constraints.basic.default_value_type_match',
             obj_ref=ctrl,
-            detail_re=r'Within the object named "control_a" the default value "123" does not match the associated type',
+            detail_re=r'Within the object named "control_a" the value "123" does not match the associated type',
         )


### PR DESCRIPTION
Complete #56 by moving logic from ADM loading (where type objects will not be bound) to constraint check which ensures type is bound).

This corrects issues in #105 and #123 